### PR TITLE
Redisinsightをサービスに登録して起動する

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -6,17 +6,31 @@
       "source_ami": "ami-0f9ae750e8274075b",
       "instance_type": "t2.micro",
       "ssh_username": "ec2-user",
-      "ami_name": "redisinsight-ami"
+      "ami_name": "redisinsight-ami_{{isotime \"2006_01_02_03_04\"}}"
     }
   ],
     "provisioners": [
+      {
+        "type": "file",
+        "destination": "/tmp/",
+        "source": "./redisinsight.service"
+      },
+      {
+        "type": "file",
+        "destination": "/tmp/",
+        "source": "./redisinsight.sh"
+      },
       {
         "type":  "shell",
         "inline": [
           "sudo yum -y update",
           "sudo yum -y install docker",
           "sudo systemctl start docker && sudo systemctl enable docker" ,
-          "sudo usermod -a -G docker ec2-user"
+          "sudo usermod -a -G docker ec2-user",
+          "sudo docker pull redislabs/redisinsight:latest",
+          "sudo mv /tmp/redisinsight.sh /usr/local/bin/",
+          "sudo mv /tmp/redisinsight.service /usr/lib/systemd/system/",
+          "sudo systemctl enable redisinsight"
         ]
       }
     ]

--- a/redisinsight.service
+++ b/redisinsight.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Redisinsight Start
+After=docker.service
+
+[Service]
+ExecStart=/usr/local/bin/redisinsight.sh
+Restart=no
+RestartSec=60s
+User=ec2-user
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/redisinsight.sh
+++ b/redisinsight.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -v redisinsight:/db -p 8001:8001 redislabs/redisinsight:latest


### PR DESCRIPTION
都度コマンドで立ち上げるのが不便なので、サービスに登録して起動するようにする.
Dockerと依存するため、Docker起動後に設定.